### PR TITLE
Remove Jorje leaks outside `ast` package

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAssignmentExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAssignmentExpression.java
@@ -22,7 +22,12 @@ public class ASTAssignmentExpression extends AbstractApexNode<AssignmentExpressi
         return visitor.visit(this, data);
     }
 
+    @Deprecated
     public AssignmentOp getOperator() {
         return node.getOp();
+    }
+
+    public AssignmentOperator getOp() {
+        return AssignmentOperator.valueOf(node.getOp());
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBinaryExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBinaryExpression.java
@@ -22,7 +22,12 @@ public class ASTBinaryExpression extends AbstractApexNode<BinaryExpression> {
         return visitor.visit(this, data);
     }
 
+    @Deprecated
     public BinaryOp getOperator() {
         return node.getOp();
+    }
+
+    public BinaryOperator getOp() {
+        return BinaryOperator.valueOf(node.getOp());
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBooleanExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBooleanExpression.java
@@ -24,9 +24,12 @@ public class ASTBooleanExpression extends AbstractApexNode<BooleanExpression> {
         return visitor.visit(this, data);
     }
 
-
+    @Deprecated
     public BooleanOp getOperator() {
         return this.node.getOp();
     }
 
+    public BooleanOperator getOp() {
+        return BooleanOperator.valueOf(this.node.getOp());
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPostfixExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPostfixExpression.java
@@ -24,8 +24,12 @@ public class ASTPostfixExpression extends AbstractApexNode<PostfixExpression> {
         return visitor.visit(this, data);
     }
 
-
+    @Deprecated
     public PostfixOp getOperator() {
         return node.getOp();
+    }
+
+    public PostfixOperator getOp() {
+        return PostfixOperator.valueOf(node.getOp());
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPrefixExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPrefixExpression.java
@@ -22,8 +22,12 @@ public class ASTPrefixExpression extends AbstractApexNode<PrefixExpression> {
         return visitor.visit(this, data);
     }
 
-
+    @Deprecated
     public PrefixOp getOperator() {
         return node.getOp();
+    }
+
+    public PrefixOperator getOp() {
+        return PrefixOperator.valueOf(node.getOp());
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexRootNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexRootNode.java
@@ -8,12 +8,12 @@ import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.ast.RootNode;
 import net.sourceforge.pmd.lang.ast.SourceCodePositioner;
 
-import apex.jorje.semantic.ast.AstNode;
+import apex.jorje.semantic.ast.compilation.Compilation;
 import apex.jorje.services.Version;
 
 @Deprecated
 @InternalApi
-public abstract class ApexRootNode<T extends AstNode> extends AbstractApexNode<T> implements RootNode {
+public abstract class ApexRootNode<T extends Compilation> extends AbstractApexNode<T> implements RootNode {
     @Deprecated
     @InternalApi
     public ApexRootNode(T node) {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AssignmentOperator.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AssignmentOperator.java
@@ -1,0 +1,67 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.ast;
+
+import apex.jorje.data.ast.AssignmentOp;
+
+/**
+ * Apex assignment operator
+ */
+public enum AssignmentOperator {
+    EQUALS("="),
+    ADDITION_EQUALS("+="),
+    SUBTRACTION_EQUALS("-="),
+    MULTIPLICATION_EQUALS("*="),
+    DIVISION_EQUALS("/="),
+    LEFT_SHIFT_EQUALS("<<="),
+    RIGHT_SHIFT_SIGNED_EQUALS(">>="),
+    RIGHT_SHIFT_UNSIGNED_EQUALS(">>>="),
+    BITWISE_AND_EQUALS("&="),
+    BITWISE_OR_EQUALS("|="),
+    BITWISE_XOR_EQUALS("^=");
+
+    private final String symbol;
+
+    AssignmentOperator(String symbol) {
+        this.symbol = symbol;
+    }
+
+    @Override
+    public String toString() {
+        return this.symbol;
+    }
+
+    /**
+     * Returns a {@link AssignmentOperator} corresponding to the given {@link AssignmentOp}.
+     */
+    public static AssignmentOperator valueOf(AssignmentOp op) {
+        switch (op) {
+        case EQUALS:
+            return EQUALS;
+        case ADDITION_EQUALS:
+            return ADDITION_EQUALS;
+        case SUBTRACTION_EQUALS:
+            return SUBTRACTION_EQUALS;
+        case MULTIPLICATION_EQUALS:
+            return MULTIPLICATION_EQUALS;
+        case DIVISION_EQUALS:
+            return DIVISION_EQUALS;
+        case LEFT_SHIFT_EQUALS:
+            return LEFT_SHIFT_EQUALS;
+        case RIGHT_SHIFT_EQUALS:
+            return RIGHT_SHIFT_SIGNED_EQUALS;
+        case UNSIGNED_RIGHT_SHIFT_EQUALS:
+            return RIGHT_SHIFT_UNSIGNED_EQUALS;
+        case AND_EQUALS:
+            return BITWISE_AND_EQUALS;
+        case OR_EQUALS:
+            return BITWISE_OR_EQUALS;
+        case XOR_EQUALS:
+            return BITWISE_XOR_EQUALS;
+        default:
+            throw new IllegalArgumentException("Invalid assignment operator " + op);
+        }
+    }
+}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/BinaryOperator.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/BinaryOperator.java
@@ -1,0 +1,64 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.ast;
+
+import apex.jorje.data.ast.BinaryOp;
+
+/**
+ * Apex binary operator
+ */
+public enum BinaryOperator {
+    ADDITION("+"),
+    SUBTRACTION("-"),
+    MULTIPLICATION("*"),
+    DIVISION("/"),
+    LEFT_SHIFT("<<"),
+    RIGHT_SHIFT_SIGNED(">>"),
+    RIGHT_SHIFT_UNSIGNED(">>>"),
+    BITWISE_AND("&"),
+    BITWISE_OR("|"),
+    BITWISE_XOR("^");
+
+    private final String symbol;
+
+    BinaryOperator(String symbol) {
+        this.symbol = symbol;
+    }
+
+    @Override
+    public String toString() {
+        return this.symbol;
+    }
+
+    /**
+     * Returns a {@link BinaryOperator} corresponding to the given {@link BinaryOp}.
+     */
+    public static BinaryOperator valueOf(BinaryOp op) {
+        switch (op) {
+        case ADDITION:
+            return ADDITION;
+        case SUBTRACTION:
+            return SUBTRACTION;
+        case MULTIPLICATION:
+            return MULTIPLICATION;
+        case DIVISION:
+            return DIVISION;
+        case LEFT_SHIFT:
+            return LEFT_SHIFT;
+        case RIGHT_SHIFT:
+            return RIGHT_SHIFT_SIGNED;
+        case UNSIGNED_RIGHT_SHIFT:
+            return RIGHT_SHIFT_UNSIGNED;
+        case AND:
+            return BITWISE_AND;
+        case OR:
+            return BITWISE_OR;
+        case XOR:
+            return BITWISE_XOR;
+        default:
+            throw new IllegalArgumentException("Invalid binary operator " + op);
+        }
+    }
+}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/BooleanOperator.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/BooleanOperator.java
@@ -1,0 +1,67 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.ast;
+
+import apex.jorje.data.ast.BooleanOp;
+
+/**
+ * Apex boolean operator
+ */
+public enum BooleanOperator {
+    EQUAL("=="),
+    NOT_EQUAL("!="),
+    ALT_NOT_EQUAL("<>"),
+    EXACTLY_EQUAL("==="),
+    EXACTLY_NOT_EQUAL("!=="),
+    LESS_THAN("<"),
+    GREATER_THAN(">"),
+    LESS_THAN_OR_EQUAL("<="),
+    GREATER_THAN_OR_EQUAL(">="),
+    LOGICAL_AND("&&"),
+    LOGICAL_OR("||");
+
+    private final String symbol;
+
+    BooleanOperator(String symbol) {
+        this.symbol = symbol;
+    }
+
+    @Override
+    public String toString() {
+        return this.symbol;
+    }
+
+    /**
+     * Returns a {@link BooleanOperator} corresponding to the given {@link BooleanOp}.
+     */
+    public static BooleanOperator valueOf(BooleanOp op) {
+        switch (op) {
+        case DOUBLE_EQUAL:
+            return EQUAL;
+        case NOT_EQUAL:
+            return NOT_EQUAL;
+        case ALT_NOT_EQUAL:
+            return ALT_NOT_EQUAL;
+        case TRIPLE_EQUAL:
+            return EXACTLY_EQUAL;
+        case NOT_TRIPLE_EQUAL:
+            return EXACTLY_NOT_EQUAL;
+        case LESS_THAN:
+            return LESS_THAN;
+        case GREATER_THAN:
+            return GREATER_THAN;
+        case LESS_THAN_EQUAL:
+            return LESS_THAN_OR_EQUAL;
+        case GREATER_THAN_EQUAL:
+            return GREATER_THAN_OR_EQUAL;
+        case AND:
+            return LOGICAL_AND;
+        case OR:
+            return LOGICAL_OR;
+        default:
+            throw new IllegalArgumentException("Invalid boolean operator " + op);
+        }
+    }
+}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/PostfixOperator.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/PostfixOperator.java
@@ -1,0 +1,40 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.ast;
+
+import apex.jorje.data.ast.PostfixOp;
+
+/**
+ * Apex postfix operator
+ */
+public enum PostfixOperator {
+    INCREMENT("++"),
+    DECREMENT("--");
+
+    private final String symbol;
+
+    PostfixOperator(String symbol) {
+        this.symbol = symbol;
+    }
+
+    @Override
+    public String toString() {
+        return this.symbol;
+    }
+
+    /**
+     * Returns a {@link PostfixOperator} corresponding to the given {@link PostfixOp}.
+     */
+    public static PostfixOperator valueOf(PostfixOp op) {
+        switch (op) {
+        case INC:
+            return INCREMENT;
+        case DEC:
+            return DECREMENT;
+        default:
+            throw new IllegalArgumentException("Invalid postfix operator " + op);
+        }
+    }
+}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/PrefixOperator.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/PrefixOperator.java
@@ -1,0 +1,52 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.ast;
+
+import apex.jorje.data.ast.PrefixOp;
+
+/**
+ * Apex prefix operator
+ */
+public enum PrefixOperator {
+    POSITIVE("+"),
+    NEGATIVE("-"),
+    LOGICAL_NOT("!"),
+    BITWISE_NOT("~"),
+    INCREMENT("++"),
+    DECREMENT("--");
+
+    private final String symbol;
+
+    PrefixOperator(String symbol) {
+        this.symbol = symbol;
+    }
+
+    @Override
+    public String toString() {
+        return this.symbol;
+    }
+
+    /**
+     * Returns a {@link PrefixOperator} corresponding to the given {@link PrefixOp}.
+     */
+    public static PrefixOperator valueOf(PrefixOp op) {
+        switch (op) {
+        case POSITIVE:
+            return POSITIVE;
+        case NEGATIVE:
+            return NEGATIVE;
+        case NOT:
+            return LOGICAL_NOT;
+        case BITWISE_COMPLEMENT:
+            return BITWISE_NOT;
+        case INC:
+            return INCREMENT;
+        case DEC:
+            return DECREMENT;
+        default:
+            throw new IllegalArgumentException("Invalid prefix operator " + op);
+        }
+    }
+}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/CycloMetric.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/CycloMetric.java
@@ -12,10 +12,9 @@ import org.apache.commons.lang3.mutable.MutableInt;
 import net.sourceforge.pmd.lang.apex.ast.ASTBooleanExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
 import net.sourceforge.pmd.lang.apex.ast.ASTStandardCondition;
+import net.sourceforge.pmd.lang.apex.ast.BooleanOperator;
 import net.sourceforge.pmd.lang.apex.metrics.impl.visitors.StandardCycloVisitor;
 import net.sourceforge.pmd.lang.metrics.MetricOptions;
-
-import apex.jorje.data.ast.BooleanOp;
 
 /**
  * See the doc for the Java metric.
@@ -44,8 +43,8 @@ public class CycloMetric extends AbstractApexOperationMetric {
         int complexity = 0;
 
         for (ASTBooleanExpression sub : subs) {
-            BooleanOp op = sub.getOperator();
-            if (op != null && (op == BooleanOp.AND || op == BooleanOp.OR)) {
+            BooleanOperator op = sub.getOp();
+            if (op == BooleanOperator.LOGICAL_AND || op == BooleanOperator.LOGICAL_OR) {
                 complexity++;
             }
         }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
@@ -19,9 +19,8 @@ import net.sourceforge.pmd.lang.apex.ast.ASTTernaryExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTWhileLoopStatement;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.ast.ApexParserVisitorAdapter;
-
-import apex.jorje.data.ast.BooleanOp;
-import apex.jorje.data.ast.PrefixOp;
+import net.sourceforge.pmd.lang.apex.ast.BooleanOperator;
+import net.sourceforge.pmd.lang.apex.ast.PrefixOperator;
 
 /**
  * @author Gwilym Kuiper
@@ -31,7 +30,7 @@ public class CognitiveComplexityVisitor extends ApexParserVisitorAdapter {
         private int complexity = 0;
         private int nestingLevel = 0;
 
-        private BooleanOp currentBooleanOperation = null;
+        private BooleanOperator currentBooleanOperation = null;
         private String methodName = null;
 
         public double getComplexity() {
@@ -53,7 +52,7 @@ public class CognitiveComplexityVisitor extends ApexParserVisitorAdapter {
             complexity++;
         }
 
-        void booleanOperation(BooleanOp op) {
+        void booleanOperation(BooleanOperator op) {
             if (currentBooleanOperation != op) {
                 if (op != null) {
                     fundamentalComplexity();
@@ -177,8 +176,8 @@ public class CognitiveComplexityVisitor extends ApexParserVisitorAdapter {
     public Object visit(ASTBooleanExpression node, Object data) {
         State state = (State) data;
 
-        BooleanOp op = node.getOperator();
-        if (op == BooleanOp.AND || op == BooleanOp.OR) {
+        BooleanOperator op = node.getOp();
+        if (op == BooleanOperator.LOGICAL_AND || op == BooleanOperator.LOGICAL_OR) {
             state.booleanOperation(op);
         }
 
@@ -189,8 +188,8 @@ public class CognitiveComplexityVisitor extends ApexParserVisitorAdapter {
     public Object visit(ASTPrefixExpression node, Object data) {
         State state = (State) data;
 
-        PrefixOp op = node.getOperator();
-        if (op == PrefixOp.NOT) {
+        PrefixOperator op = node.getOp();
+        if (op == PrefixOperator.LOGICAL_NOT) {
             state.booleanOperation(null);
         }
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldTest.java
@@ -7,13 +7,11 @@ package net.sourceforge.pmd.lang.apex.ast;
 import org.junit.Assert;
 import org.junit.Test;
 
-import apex.jorje.semantic.ast.compilation.Compilation;
-
 public class ASTFieldTest extends ApexParserTestBase {
 
     @Test
     public void testGetType() {
-        ApexNode<Compilation> node = parse("public class Foo { private String myField = 'a'; }");
+        ApexNode<?> node = parse("public class Foo { private String myField = 'a'; }");
         ASTField field = node.getFirstDescendantOfType(ASTField.class);
 
         Assert.assertEquals("myField", field.getImage());
@@ -23,7 +21,7 @@ public class ASTFieldTest extends ApexParserTestBase {
 
     @Test
     public void testGetValue() {
-        ApexNode<Compilation> node = parse("public class Foo { private String myField = 'a'; }");
+        ApexNode<?> node = parse("public class Foo { private String myField = 'a'; }");
         ASTField field = node.getFirstDescendantOfType(ASTField.class);
 
         Assert.assertEquals("a", field.getValue());
@@ -31,7 +29,7 @@ public class ASTFieldTest extends ApexParserTestBase {
 
     @Test
     public void testGetNoValue() {
-        ApexNode<Compilation> node = parse("public class Foo { private String myField; }");
+        ApexNode<?> node = parse("public class Foo { private String myField; }");
         ASTField field = node.getFirstDescendantOfType(ASTField.class);
 
         Assert.assertNull(field.getValue());

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTMethodTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTMethodTest.java
@@ -9,13 +9,11 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 
-import apex.jorje.semantic.ast.compilation.Compilation;
-
 public class ASTMethodTest extends ApexParserTestBase {
 
     @Test
     public void testConstructorName() {
-        ApexNode<Compilation> node = parse("public class Foo { public Foo() {} public void bar() {} }");
+        ApexNode<?> node = parse("public class Foo { public Foo() {} public void bar() {} }");
         Assert.assertSame(ASTUserClass.class, node.getClass());
         List<ASTMethod> methods = node.findChildrenOfType(ASTMethod.class);
         Assert.assertEquals("Foo", methods.get(0).getImage()); // constructor

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTNewKeyValueObjectExpressionTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTNewKeyValueObjectExpressionTest.java
@@ -9,13 +9,11 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 
-import apex.jorje.semantic.ast.compilation.Compilation;
-
 public class ASTNewKeyValueObjectExpressionTest extends ApexParserTestBase {
 
     @Test
     public void testParameterName() {
-        ApexNode<Compilation> node = parse("public class Foo { \n"
+        ApexNode<?> node = parse("public class Foo { \n"
                 + "    public void foo(String newName, String tempID) { \n"
                 + "        if (Contact.sObjectType.getDescribe().isCreateable() && Contact.sObjectType.getDescribe().isUpdateable()) {\n"
                 + "            upsert new Contact(FirstName = 'First', LastName = 'Last', Phone = '414-414-4414');\n"

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTSoqlExpressionTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTSoqlExpressionTest.java
@@ -7,13 +7,11 @@ package net.sourceforge.pmd.lang.apex.ast;
 import org.junit.Assert;
 import org.junit.Test;
 
-import apex.jorje.semantic.ast.compilation.Compilation;
-
 public class ASTSoqlExpressionTest extends ApexParserTestBase {
 
     @Test
     public void testQuery() {
-        ApexNode<Compilation> node = parse("class Foo { void test1() { Account acc = [SELECT col FROM Account]; } }");
+        ApexNode<?> node = parse("class Foo { void test1() { Account acc = [SELECT col FROM Account]; } }");
         ASTSoqlExpression soqlExpression = node.getFirstDescendantOfType(ASTSoqlExpression.class);
         Assert.assertEquals("SELECT col FROM Account", soqlExpression.getQuery());
     }

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTSwitchStatementTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTSwitchStatementTest.java
@@ -9,13 +9,11 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 
-import apex.jorje.semantic.ast.compilation.Compilation;
-
 public class ASTSwitchStatementTest extends ApexParserTestBase {
 
     @Test
     public void testExamples() {
-        ApexNode<Compilation> node = parseResource("SwitchStatements.cls");
+        ApexNode<?> node = parseResource("SwitchStatements.cls");
         List<ASTSwitchStatement> switchStatements = node.findDescendantsOfType(ASTSwitchStatement.class);
         Assert.assertEquals(4, switchStatements.size());
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTTryCatchFinallyBlockStatementTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTTryCatchFinallyBlockStatementTest.java
@@ -7,13 +7,11 @@ package net.sourceforge.pmd.lang.apex.ast;
 import org.junit.Assert;
 import org.junit.Test;
 
-import apex.jorje.semantic.ast.compilation.Compilation;
-
 public class ASTTryCatchFinallyBlockStatementTest extends ApexParserTestBase {
 
     @Test
     public void testTryFinally() {
-        ApexNode<Compilation> node = parse("class Foo { void bar() { try { methodCall(); } finally { methodCall(); } } }");
+        ApexNode<?> node = parse("class Foo { void bar() { try { methodCall(); } finally { methodCall(); } } }");
         ASTTryCatchFinallyBlockStatement statement = node.getFirstDescendantOfType(ASTTryCatchFinallyBlockStatement.class);
         Assert.assertNotNull(statement.getTryBlock());
         Assert.assertEquals(0, statement.getTryBlock().getIndexInParent());
@@ -24,7 +22,7 @@ public class ASTTryCatchFinallyBlockStatementTest extends ApexParserTestBase {
 
     @Test
     public void testTryCatch() {
-        ApexNode<Compilation> node = parse("class Foo { void bar() { try { methodCall(); } catch (Exception e) { methodCall(); } } }");
+        ApexNode<?> node = parse("class Foo { void bar() { try { methodCall(); } catch (Exception e) { methodCall(); } } }");
         ASTTryCatchFinallyBlockStatement statement = node.getFirstDescendantOfType(ASTTryCatchFinallyBlockStatement.class);
         Assert.assertNotNull(statement.getTryBlock());
         Assert.assertEquals(0, statement.getTryBlock().getIndexInParent());
@@ -36,7 +34,7 @@ public class ASTTryCatchFinallyBlockStatementTest extends ApexParserTestBase {
 
     @Test
     public void testTryCatchFinally() {
-        ApexNode<Compilation> node = parse("class Foo { void bar() { try { methodCall(); } catch (Exception e) { methodCall(); } finally { } } }");
+        ApexNode<?> node = parse("class Foo { void bar() { try { methodCall(); } catch (Exception e) { methodCall(); } finally { } } }");
         ASTTryCatchFinallyBlockStatement statement = node.getFirstDescendantOfType(ASTTryCatchFinallyBlockStatement.class);
         Assert.assertNotNull(statement.getTryBlock());
         Assert.assertEquals(0, statement.getTryBlock().getIndexInParent());

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClassTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClassTest.java
@@ -9,20 +9,18 @@ import java.util.Arrays;
 import org.junit.Assert;
 import org.junit.Test;
 
-import apex.jorje.semantic.ast.compilation.Compilation;
-
 public class ASTUserClassTest extends ApexParserTestBase {
 
     @Test
     public void testClassName() {
-        ApexNode<Compilation> node = parse("class Foo { }");
+        ApexNode<?> node = parse("class Foo { }");
         Assert.assertSame(ASTUserClass.class, node.getClass());
         Assert.assertEquals("Foo", node.getImage());
     }
 
     @Test
     public void testInnerClassName() {
-        ApexNode<Compilation> node = parse("class Foo { class Bar { } }");
+        ApexNode<?> node = parse("class Foo { class Bar { } }");
         Assert.assertSame(ASTUserClass.class, node.getClass());
         ASTUserClass innerNode = node.getFirstDescendantOfType(ASTUserClass.class);
         Assert.assertNotNull(innerNode);

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTUserEnumTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTUserEnumTest.java
@@ -7,13 +7,11 @@ package net.sourceforge.pmd.lang.apex.ast;
 import org.junit.Assert;
 import org.junit.Test;
 
-import apex.jorje.semantic.ast.compilation.Compilation;
-
 public class ASTUserEnumTest extends ApexParserTestBase {
 
     @Test
     public void testEnumName() {
-        ApexNode<Compilation> node = parse("class Foo { enum Bar { } }");
+        ApexNode<?> node = parse("class Foo { enum Bar { } }");
         Assert.assertSame(ASTUserClass.class, node.getClass());
         ASTUserEnum enumNode = node.getFirstDescendantOfType(ASTUserEnum.class);
         Assert.assertNotNull(enumNode);

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTUserInterfaceTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTUserInterfaceTest.java
@@ -7,20 +7,18 @@ package net.sourceforge.pmd.lang.apex.ast;
 import org.junit.Assert;
 import org.junit.Test;
 
-import apex.jorje.semantic.ast.compilation.Compilation;
-
 public class ASTUserInterfaceTest extends ApexParserTestBase {
 
     @Test
     public void testInterfaceName() {
-        ApexNode<Compilation> node = parse("interface Foo { }");
+        ApexNode<?> node = parse("interface Foo { }");
         Assert.assertSame(ASTUserInterface.class, node.getClass());
         Assert.assertEquals("Foo", node.getImage());
     }
 
     @Test
     public void testInnerInterfaceName() {
-        ApexNode<Compilation> node = parse("class Foo { interface Bar { } }");
+        ApexNode<?> node = parse("class Foo { interface Bar { } }");
         Assert.assertSame(ASTUserClass.class, node.getClass());
         ASTUserInterface innerNode = node.getFirstDescendantOfType(ASTUserInterface.class);
         Assert.assertNotNull(innerNode);

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexParserTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexParserTest.java
@@ -21,8 +21,6 @@ import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.ast.xpath.internal.FileNameXPathFunction;
 import net.sourceforge.pmd.util.IOUtil;
 
-import apex.jorje.semantic.ast.compilation.Compilation;
-
 public class ApexParserTest extends ApexParserTestBase {
 
     @Test
@@ -33,7 +31,7 @@ public class ApexParserTest extends ApexParserTestBase {
             + "        \n" + "    }\n" + "}";
 
         // Exercise
-        ApexNode<Compilation> rootNode = parse(code);
+        ApexNode<?> rootNode = parse(code);
 
         // Verify
         List<ASTMethod> methods = rootNode.findDescendantsOfType(ASTMethod.class);
@@ -59,18 +57,18 @@ public class ApexParserTest extends ApexParserTestBase {
 
     @Test
     public void verifyLineColumnNumbers() {
-        ApexNode<Compilation> rootNode = parse(testCodeForLineNumbers);
+        ApexNode<?> rootNode = parse(testCodeForLineNumbers);
         assertLineNumbersForTestCode(rootNode);
     }
 
     @Test
     public void verifyLineColumnNumbersWithWindowsLineEndings() {
         String windowsLineEndings = testCodeForLineNumbers.replaceAll(" \n", "\r\n");
-        ApexNode<Compilation> rootNode = parse(windowsLineEndings);
+        ApexNode<?> rootNode = parse(windowsLineEndings);
         assertLineNumbersForTestCode(rootNode);
     }
 
-    private void assertLineNumbersForTestCode(ApexNode<Compilation> rootNode) {
+    private void assertLineNumbersForTestCode(ApexNode<?> rootNode) {
         // whole source code, well from the beginning of the class
         // name Modifier of the class - doesn't work. This node just
         // sees the identifier ("SimpleClass")
@@ -107,7 +105,7 @@ public class ApexParserTest extends ApexParserTestBase {
                 + "    }\n" // line 5
                 + "}\n"; // line 6
 
-        ApexNode<Compilation> rootNode = parse(code);
+        ApexNode<?> rootNode = parse(code);
 
         Node method1 = rootNode.getChild(1);
         assertEquals("Wrong begin line", 2, method1.getBeginLine());
@@ -129,7 +127,7 @@ public class ApexParserTest extends ApexParserTestBase {
             + "    }\n" // line 5
             + "}\n"; // line 6
 
-        ApexNode<Compilation> root = parse(code);
+        ApexNode<?> root = parse(code);
 
         assertThat(root, instanceOf(ASTUserClass.class));
         ApexNode<?> comment = root.getChild(0);
@@ -154,7 +152,7 @@ public class ApexParserTest extends ApexParserTestBase {
         for (File file : fList) {
             if (file.isFile() && file.getName().endsWith(".cls")) {
                 String sourceCode = IOUtil.readFileToString(file, StandardCharsets.UTF_8);
-                ApexNode<Compilation> rootNode = parse(sourceCode);
+                ApexNode<?> rootNode = parse(sourceCode);
                 Assert.assertNotNull(rootNode);
             }
         }
@@ -168,7 +166,7 @@ public class ApexParserTest extends ApexParserTestBase {
     public void parseInheritedSharingClass() throws IOException {
         String source = IOUtil.readToString(ApexParserTest.class.getResourceAsStream("InheritedSharing.cls"),
                 StandardCharsets.UTF_8);
-        ApexNode<Compilation> rootNode = parse(source);
+        ApexNode<?> rootNode = parse(source);
         Assert.assertNotNull(rootNode);
     }
 
@@ -181,7 +179,7 @@ public class ApexParserTest extends ApexParserTestBase {
     public void stackOverflowDuringClassParsing() throws Exception {
         String source = IOUtil.readToString(ApexParserTest.class.getResourceAsStream("StackOverflowClass.cls"),
                 StandardCharsets.UTF_8);
-        ApexNode<Compilation> rootNode = parse(source);
+        ApexNode<?> rootNode = parse(source);
         Assert.assertNotNull(rootNode);
 
         int count = visitPosition(rootNode, 0);
@@ -193,7 +191,7 @@ public class ApexParserTest extends ApexParserTestBase {
         String source = IOUtil.readToString(ApexParserTest.class.getResourceAsStream("InnerClassLocations.cls"),
                 StandardCharsets.UTF_8);
         source = source.replaceAll("\r\n", "\n");
-        ApexNode<Compilation> rootNode = parse(source);
+        ApexNode<?> rootNode = parse(source);
         Assert.assertNotNull(rootNode);
 
         visitPosition(rootNode, 0);

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexParserTestBase.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexParserTestBase.java
@@ -11,15 +11,15 @@ public class ApexParserTestBase {
     protected final ApexParsingHelper apex = ApexParsingHelper.DEFAULT.withResourceContext(getClass());
 
 
-    protected ApexNode<Compilation> parse(String code) {
+    protected ApexRootNode<? extends Compilation> parse(String code) {
         return apex.parse(code);
     }
 
-    protected ApexNode<? extends Compilation> parse(String code, String fileName) {
+    protected ApexRootNode<? extends Compilation> parse(String code, String fileName) {
         return apex.parse(code, null, fileName);
     }
 
-    protected ApexNode<Compilation> parseResource(String code) {
+    protected ApexRootNode<? extends Compilation> parseResource(String code) {
         return apex.parseResource(code);
     }
 }

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexQualifiedNameTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexQualifiedNameTest.java
@@ -13,9 +13,6 @@ import java.util.List;
 
 import org.junit.Test;
 
-import apex.jorje.semantic.ast.compilation.Compilation;
-
-
 /**
  * @author Clément Fournier
  */
@@ -23,9 +20,9 @@ public class ApexQualifiedNameTest extends ApexParserTestBase {
 
     @Test
     public void testClass() {
-        ApexNode<Compilation> root = parse("public class Foo {}");
+        ApexNode<?> root = parse("public class Foo {}");
 
-        ApexQualifiedName qname = ASTUserClass.class.cast(root).getQualifiedName();
+        ApexQualifiedName qname = ((ASTUserClass) root).getQualifiedName();
         assertEquals("c__Foo", qname.toString());
         assertEquals(1, qname.getClasses().length);
         assertNotNull(qname.getNameSpace());
@@ -35,7 +32,7 @@ public class ApexQualifiedNameTest extends ApexParserTestBase {
 
     @Test
     public void testNestedClass() {
-        ApexNode<Compilation> root = parse("public class Foo { class Bar {}}");
+        ApexNode<?> root = parse("public class Foo { class Bar {}}");
 
         ApexQualifiedName qname = root.getFirstDescendantOfType(ASTUserClass.class).getQualifiedName();
         assertEquals("c__Foo.Bar", qname.toString());
@@ -47,7 +44,7 @@ public class ApexQualifiedNameTest extends ApexParserTestBase {
 
     @Test
     public void testSimpleMethod() {
-        ApexNode<Compilation> root = parse("public class Foo { String foo() {}}");
+        ApexNode<?> root = parse("public class Foo { String foo() {}}");
         ApexQualifiedName qname = root.getFirstDescendantOfType(ASTMethod.class).getQualifiedName();
         assertEquals("c__Foo#foo()", qname.toString());
         assertEquals(1, qname.getClasses().length);
@@ -58,7 +55,7 @@ public class ApexQualifiedNameTest extends ApexParserTestBase {
 
     @Test
     public void testMethodWithArguments() {
-        ApexNode<Compilation> root = parse("public class Foo { String foo(String h, Foo g) {}}");
+        ApexNode<?> root = parse("public class Foo { String foo(String h, Foo g) {}}");
         ApexQualifiedName qname = root.getFirstDescendantOfType(ASTMethod.class).getQualifiedName();
         assertEquals("c__Foo#foo(String, Foo)", qname.toString());
         assertEquals(1, qname.getClasses().length);
@@ -69,7 +66,7 @@ public class ApexQualifiedNameTest extends ApexParserTestBase {
 
     @Test
     public void testOverLoads() {
-        ApexNode<Compilation> root = parse("public class Foo { "
+        ApexNode<?> root = parse("public class Foo { "
                                                                  + "String foo(String h) {} "
                                                                  + "String foo(int c) {}"
                                                                  + "String foo(Foo c) {}}");
@@ -88,7 +85,7 @@ public class ApexQualifiedNameTest extends ApexParserTestBase {
 
     @Test
     public void testTrigger() {
-        ApexNode<Compilation> root = parse("trigger myAccountTrigger on Account (before insert, before update) {}");
+        ApexNode<?> root = parse("trigger myAccountTrigger on Account (before insert, before update) {}");
 
 
         List<ASTMethod> methods = root.findDescendantsOfType(ASTMethod.class);

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/metrics/ApexProjectMirrorTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/metrics/ApexProjectMirrorTest.java
@@ -27,14 +27,12 @@ import net.sourceforge.pmd.lang.metrics.MetricKeyUtil;
 import net.sourceforge.pmd.lang.metrics.MetricOptions;
 import net.sourceforge.pmd.lang.metrics.MetricsUtil;
 
-import apex.jorje.semantic.ast.compilation.Compilation;
-
 /**
  * @author Clément Fournier
  */
 public class ApexProjectMirrorTest extends ApexParserTestBase {
 
-    private static ApexNode<Compilation> acu;
+    private static ApexNode<?> acu;
     private MetricKey<ASTUserClassOrInterface<?>> classMetricKey = MetricKeyUtil.of(null, new RandomClassMetric());
     private MetricKey<ASTMethod> opMetricKey = MetricKeyUtil.of(null, new RandomOperationMetric());
 
@@ -70,7 +68,7 @@ public class ApexProjectMirrorTest extends ApexParserTestBase {
     }
 
 
-    private List<Integer> visitWith(ApexNode<Compilation> acu, final boolean force) {
+    private List<Integer> visitWith(ApexNode<?> acu, final boolean force) {
         final List<Integer> result = new ArrayList<>();
 
         acu.jjtAccept(new ApexParserVisitorAdapter() {

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/multifile/ApexMultifileVisitorTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/multifile/ApexMultifileVisitorTest.java
@@ -18,8 +18,6 @@ import net.sourceforge.pmd.lang.apex.ast.ApexParserVisitorAdapter;
 import net.sourceforge.pmd.lang.apex.metrics.ApexSignatureMatcher;
 import net.sourceforge.pmd.lang.apex.metrics.signature.ApexOperationSigMask;
 
-import apex.jorje.semantic.ast.compilation.Compilation;
-
 /**
  * @author Clément Fournier
  */
@@ -33,7 +31,7 @@ public class ApexMultifileVisitorTest extends ApexParserTestBase {
 
     @Test
     public void testOperationsAreThere() throws IOException {
-        ApexNode<Compilation> acu = parseResource("MetadataDeployController.cls");
+        ApexNode<?> acu = parseResource("MetadataDeployController.cls");
 
         final ApexSignatureMatcher toplevel = ApexProjectMirror.INSTANCE;
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/AbstractApexRuleTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/AbstractApexRuleTest.java
@@ -19,8 +19,6 @@ import net.sourceforge.pmd.lang.apex.ast.ASTUserTrigger;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.ast.ApexParserTestBase;
 
-import apex.jorje.semantic.ast.compilation.Compilation;
-
 public class AbstractApexRuleTest extends ApexParserTestBase {
 
     @Test
@@ -44,7 +42,7 @@ public class AbstractApexRuleTest extends ApexParserTestBase {
     }
 
     private void run(String code) {
-        ApexNode<Compilation> node = parse(code);
+        ApexNode<?> node = parse(code);
         TopLevelRule rule = new TopLevelRule();
         RuleContext ctx = new RuleContext();
         ctx.setLanguageVersion(apex.getDefaultVersion());


### PR DESCRIPTION
Operators
- Create `ApexOperator` class to wrap internal operator classes.
- Refactor operator expression nodes to use `ApexOperator`.
- Refactor metrics classes to use `ApexOperator`.

Tests
- Remove references to internal Jorje nodes.