### PR TITLE
Deprecate `ApexNode` type parameter

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTCommentContainer.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTCommentContainer.java
@@ -13,7 +13,7 @@ import net.sourceforge.pmd.annotation.Experimental;
  * comments. This is useful for rules which need to know whether a node did contain comments.
  */
 @Experimental
-public interface ASTCommentContainer<T extends Node> extends ApexNode<T> {
+public interface ASTCommentContainer extends ApexNode<Void> {
 
     boolean getContainsComment();
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClassOrInterface.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClassOrInterface.java
@@ -8,8 +8,10 @@ import com.google.summit.ast.Node;
 
 /**
  * @author Clément Fournier
+ *
+ * @param <T> placeholder
  */
-public interface ASTUserClassOrInterface<T extends Node> extends ApexQualifiableNode, ApexNode<T> {
+public interface ASTUserClassOrInterface<T> extends ApexQualifiableNode, ApexNode<Void> {
 
     /**
      * Finds the type kind of this declaration.

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexCommentContainerNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexCommentContainerNode.java
@@ -11,7 +11,7 @@ import com.google.summit.ast.Node;
  *
  * @param <T> the node type
  */
-abstract class AbstractApexCommentContainerNode<T extends Node> extends AbstractApexNode<T> implements ASTCommentContainer<T> {
+abstract class AbstractApexCommentContainerNode<T extends Node> extends AbstractApexNode<T> implements ASTCommentContainer {
 
     private boolean containsComment = false;
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNode.java
@@ -13,7 +13,7 @@ import net.sourceforge.pmd.lang.ast.SourceCodePositioner;
  */
 @Deprecated
 @InternalApi
-public abstract class AbstractApexNode<T extends Node> extends AbstractApexNodeBase implements ApexNode<T> {
+public abstract class AbstractApexNode<T extends Node> extends AbstractApexNodeBase implements ApexNode<Void> {
 
     protected final T node;
 
@@ -49,13 +49,6 @@ public abstract class AbstractApexNode<T extends Node> extends AbstractApexNodeB
 
     protected void handleSourceCode(String source) {
         // default implementation does nothing
-    }
-
-    @Deprecated
-    @InternalApi
-    @Override
-    public T getNode() {
-        return node;
     }
 
     @Override

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexNode.java
@@ -8,12 +8,11 @@ import net.sourceforge.pmd.lang.ast.Node;
 
 /**
  * Root interface implemented by all Apex nodes. Apex nodes wrap a tree
- * obtained from an external parser (Jorje). The underlying AST node is
- * available with {@link #getNode()}.
+ * obtained from an external parser.
  *
- * @param <T> Type of the underlying Jorje node
+ * @param <T> placeholder
  */
-public interface ApexNode<T extends com.google.summit.ast.Node> extends Node {
+public interface ApexNode<T> extends Node {
 
     /**
      * Accept the visitor.
@@ -29,16 +28,6 @@ public interface ApexNode<T extends com.google.summit.ast.Node> extends Node {
      */
     @Deprecated
     Object childrenAccept(ApexParserVisitor visitor, Object data);
-
-
-    /**
-     * Get the underlying AST node.
-     * @deprecated the underlying AST node should not be available outside of the AST node.
-     *      If information is needed from the underlying node, then PMD's AST node need to expose
-     *      this information.
-     */
-    @Deprecated
-    T getNode();
 
 
     @Override

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexParser.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexParser.java
@@ -42,7 +42,7 @@ public class ApexParser {
         return null;
     }
 
-    public ApexNode<CompilationUnit> parse(final Reader reader) {
+    public ApexNode<?> parse(final Reader reader) {
         try {
             final String sourceCode = IOUtil.readToString(reader);
             final CompilationUnit astRoot = parseApex(sourceCode);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexTreeBuilder.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexTreeBuilder.java
@@ -178,7 +178,7 @@ public final class ApexTreeBuilder {
         }
     }
 
-    public <T extends Node> ApexNode<T> build(T astNode) {
+    public <T extends Node> ApexNode<?> build(T astNode) {
         // Create a Node
         AbstractApexNode<T> node = createNodeAdapter(astNode);
         node.handleSourceCode(sourceCode);
@@ -219,7 +219,7 @@ public final class ApexTreeBuilder {
         return node;
     }
 
-    private boolean containsComments(ASTCommentContainer<?> commentContainer) {
+    private boolean containsComments(ASTCommentContainer commentContainer) {
         /*
         Location loc = commentContainer.getNode().getLoc();
         if (!Locations.isReal(loc)) {


### PR DESCRIPTION
- Replace `ApexNode` type arguments with `Void`
- Remove `ApexNode.getNode`
- Remove `ASTCommentContainer` type parameter
- Deprecate `ASTUserClassOrInterface` type parameter

According to previous [discussion](https://github.com/eklimo/pmd/pull/4#discussion_r933698541)