### PR TITLE
Restructure base classes

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotation.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotation.java
@@ -12,7 +12,7 @@ import java.util.TreeSet;
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTAnnotation extends AbstractApexNode<Node> {
+public class ASTAnnotation extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotationParameter.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotationParameter.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTAnnotationParameter extends AbstractApexNode<Node> {
+public class ASTAnnotationParameter extends AbstractApexNode.Single<Node> {
     public static final String SEE_ALL_DATA = "seeAllData";
 
     @Deprecated

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTArrayLoadExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTArrayLoadExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTArrayLoadExpression extends AbstractApexNode<Node> {
+public class ASTArrayLoadExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTArrayStoreExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTArrayStoreExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTArrayStoreExpression extends AbstractApexNode<Node> {
+public class ASTArrayStoreExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAssignmentExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAssignmentExpression.java
@@ -8,7 +8,7 @@ import net.sourceforge.pmd.annotation.InternalApi;
 
 import com.google.summit.ast.expression.AssignExpression;
 
-public class ASTAssignmentExpression extends AbstractApexNode<AssignExpression> {
+public class ASTAssignmentExpression extends AbstractApexNode.Single<AssignExpression> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBinaryExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBinaryExpression.java
@@ -8,7 +8,7 @@ import net.sourceforge.pmd.annotation.InternalApi;
 
 import com.google.summit.ast.expression.BinaryExpression;
 
-public class ASTBinaryExpression extends AbstractApexNode<BinaryExpression> {
+public class ASTBinaryExpression extends AbstractApexNode.Single<BinaryExpression> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBindExpressions.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBindExpressions.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTBindExpressions extends AbstractApexNode<Node> {
+public class ASTBindExpressions extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBlockStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBlockStatement.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTBlockStatement extends AbstractApexNode<Node> {
+public class ASTBlockStatement extends AbstractApexNode.Single<Node> {
     private boolean curlyBrace;
 
     @Deprecated

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBooleanExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBooleanExpression.java
@@ -8,7 +8,7 @@ import net.sourceforge.pmd.annotation.InternalApi;
 
 import com.google.summit.ast.expression.BinaryExpression;
 
-public class ASTBooleanExpression extends AbstractApexNode<BinaryExpression> {
+public class ASTBooleanExpression extends AbstractApexNode.Single<BinaryExpression> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBreakStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBreakStatement.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTBreakStatement extends AbstractApexNode<Node> {
+public class ASTBreakStatement extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBridgeMethodCreator.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBridgeMethodCreator.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTBridgeMethodCreator extends AbstractApexNode<Node> {
+public class ASTBridgeMethodCreator extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTCastExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTCastExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTCastExpression extends AbstractApexNode<Node> {
+public class ASTCastExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTClassRefExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTClassRefExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTClassRefExpression extends AbstractApexNode<Node> {
+public class ASTClassRefExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTConstructorPreamble.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTConstructorPreamble.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTConstructorPreamble extends AbstractApexNode<Node> {
+public class ASTConstructorPreamble extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTConstructorPreambleStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTConstructorPreambleStatement.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTConstructorPreambleStatement extends AbstractApexNode<Node> {
+public class ASTConstructorPreambleStatement extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTContinueStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTContinueStatement.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTContinueStatement extends AbstractApexNode<Node> {
+public class ASTContinueStatement extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlDeleteStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlDeleteStatement.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTDmlDeleteStatement extends AbstractApexNode<Node> {
+public class ASTDmlDeleteStatement extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlInsertStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlInsertStatement.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTDmlInsertStatement extends AbstractApexNode<Node> {
+public class ASTDmlInsertStatement extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlMergeStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlMergeStatement.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTDmlMergeStatement extends AbstractApexNode<Node> {
+public class ASTDmlMergeStatement extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlUndeleteStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlUndeleteStatement.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTDmlUndeleteStatement extends AbstractApexNode<Node> {
+public class ASTDmlUndeleteStatement extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlUpdateStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlUpdateStatement.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTDmlUpdateStatement extends AbstractApexNode<Node> {
+public class ASTDmlUpdateStatement extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlUpsertStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlUpsertStatement.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTDmlUpsertStatement extends AbstractApexNode<Node> {
+public class ASTDmlUpsertStatement extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDoLoopStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDoLoopStatement.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTDoLoopStatement extends AbstractApexNode<Node> {
+public class ASTDoLoopStatement extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTElseWhenBlock.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTElseWhenBlock.java
@@ -6,7 +6,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 
 import com.google.summit.ast.Node;
 
-public final class ASTElseWhenBlock extends AbstractApexNode<Node> {
+public final class ASTElseWhenBlock extends AbstractApexNode.Single<Node> {
 
 
     ASTElseWhenBlock(Node node) {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTEmptyReferenceExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTEmptyReferenceExpression.java
@@ -6,7 +6,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 
 import com.google.summit.ast.Node;
 
-public final class ASTEmptyReferenceExpression extends AbstractApexNode<Node> {
+public final class ASTEmptyReferenceExpression extends AbstractApexNode.Single<Node> {
 
 
     ASTEmptyReferenceExpression(Node node) {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTExpression extends AbstractApexNode<Node> {
+public class ASTExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTExpressionStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTExpressionStatement.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTExpressionStatement extends AbstractApexNode<Node> {
+public class ASTExpressionStatement extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTField.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTField.java
@@ -8,7 +8,7 @@ import com.google.summit.ast.Node;
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTField extends AbstractApexNode<Node> implements CanSuppressWarnings {
+public class ASTField extends AbstractApexNode.Single<Node> implements CanSuppressWarnings {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclaration.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclaration.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTFieldDeclaration extends AbstractApexNode<Node> {
+public class ASTFieldDeclaration extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclarationStatements.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclarationStatements.java
@@ -12,7 +12,7 @@ import java.util.stream.Collectors;
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTFieldDeclarationStatements extends AbstractApexNode<Node>
+public class ASTFieldDeclarationStatements extends AbstractApexNode.Single<Node>
         implements CanSuppressWarnings {
 
     @Deprecated

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTForEachStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTForEachStatement.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTForEachStatement extends AbstractApexNode<Node> {
+public class ASTForEachStatement extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTForLoopStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTForLoopStatement.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTForLoopStatement extends AbstractApexNode<Node> {
+public class ASTForLoopStatement extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFormalComment.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFormalComment.java
@@ -10,7 +10,7 @@ import org.antlr.runtime.Token;
 
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTFormalComment extends AbstractApexNode<Node> {
+public class ASTFormalComment extends AbstractApexNode.Single<Node> {
 
     private final String image;
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTIdentifierCase.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTIdentifierCase.java
@@ -6,7 +6,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 
 import com.google.summit.ast.Node;
 
-public final class ASTIdentifierCase extends AbstractApexNode<Node> {
+public final class ASTIdentifierCase extends AbstractApexNode.Single<Node> {
 
 
     ASTIdentifierCase(Node node) {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTIfBlockStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTIfBlockStatement.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTIfBlockStatement extends AbstractApexNode<Node> {
+public class ASTIfBlockStatement extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTIfElseBlockStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTIfElseBlockStatement.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTIfElseBlockStatement extends AbstractApexNode<Node> {
+public class ASTIfElseBlockStatement extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTIllegalStoreExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTIllegalStoreExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTIllegalStoreExpression extends AbstractApexNode<Node> {
+public class ASTIllegalStoreExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTInstanceOfExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTInstanceOfExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTInstanceOfExpression extends AbstractApexNode<Node> {
+public class ASTInstanceOfExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTJavaMethodCallExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTJavaMethodCallExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTJavaMethodCallExpression extends AbstractApexNode<Node> {
+public class ASTJavaMethodCallExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTJavaVariableExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTJavaVariableExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTJavaVariableExpression extends AbstractApexNode<Node> {
+public class ASTJavaVariableExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTLiteralCase.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTLiteralCase.java
@@ -6,7 +6,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 
 import com.google.summit.ast.Node;
 
-public final class ASTLiteralCase extends AbstractApexNode<Node> {
+public final class ASTLiteralCase extends AbstractApexNode.Single<Node> {
 
 
     ASTLiteralCase(Node node) {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTLiteralExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTLiteralExpression.java
@@ -11,7 +11,7 @@ import org.apache.commons.lang3.reflect.FieldUtils;
 
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTLiteralExpression extends AbstractApexNode<Node> {
+public class ASTLiteralExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMapEntryNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMapEntryNode.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTMapEntryNode extends AbstractApexNode<Node> {
+public class ASTMapEntryNode extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethod.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethod.java
@@ -10,7 +10,7 @@ import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.apex.metrics.signature.ApexOperationSignature;
 import net.sourceforge.pmd.lang.ast.SignedNode;
 
-public class ASTMethod extends AbstractApexNode<Node> implements ApexQualifiableNode,
+public class ASTMethod extends AbstractApexNode.Single<Node> implements ApexQualifiableNode,
        SignedNode<ASTMethod>, CanSuppressWarnings {
 
     @Deprecated

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethodBlockStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethodBlockStatement.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTMethodBlockStatement extends AbstractApexNode<Node> {
+public class ASTMethodBlockStatement extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethodCallExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethodCallExpression.java
@@ -9,7 +9,7 @@ import java.util.Iterator;
 
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTMethodCallExpression extends AbstractApexNode<Node> {
+public class ASTMethodCallExpression extends AbstractApexNode.Single<Node> {
     @Deprecated
     @InternalApi
     public ASTMethodCallExpression(Node methodCallExpression) {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTModifier.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTModifier.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTModifier extends AbstractApexNode<Node> {
+public class ASTModifier extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTModifierNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTModifierNode.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTModifierNode extends AbstractApexNode<Node> implements AccessNode {
+public class ASTModifierNode extends AbstractApexNode.Single<Node> implements AccessNode {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTModifierOrAnnotation.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTModifierOrAnnotation.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTModifierOrAnnotation extends AbstractApexNode<Node> {
+public class ASTModifierOrAnnotation extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMultiStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMultiStatement.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTMultiStatement extends AbstractApexNode<Node> {
+public class ASTMultiStatement extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNestedExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNestedExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTNestedExpression extends AbstractApexNode<Node> {
+public class ASTNestedExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNestedStoreExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNestedStoreExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTNestedStoreExpression extends AbstractApexNode<Node> {
+public class ASTNestedStoreExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewKeyValueObjectExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewKeyValueObjectExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTNewKeyValueObjectExpression extends AbstractApexNode<Node> {
+public class ASTNewKeyValueObjectExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewListInitExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewListInitExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTNewListInitExpression extends AbstractApexNode<Node> {
+public class ASTNewListInitExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewListLiteralExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewListLiteralExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTNewListLiteralExpression extends AbstractApexNode<Node> {
+public class ASTNewListLiteralExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewMapInitExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewMapInitExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTNewMapInitExpression extends AbstractApexNode<Node> {
+public class ASTNewMapInitExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewMapLiteralExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewMapLiteralExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTNewMapLiteralExpression extends AbstractApexNode<Node> {
+public class ASTNewMapLiteralExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewObjectExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewObjectExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTNewObjectExpression extends AbstractApexNode<Node> {
+public class ASTNewObjectExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewSetInitExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewSetInitExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTNewSetInitExpression extends AbstractApexNode<Node> {
+public class ASTNewSetInitExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewSetLiteralExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewSetLiteralExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTNewSetLiteralExpression extends AbstractApexNode<Node> {
+public class ASTNewSetLiteralExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPackageVersionExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPackageVersionExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTPackageVersionExpression extends AbstractApexNode<Node> {
+public class ASTPackageVersionExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTParameter.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTParameter.java
@@ -8,7 +8,7 @@ import com.google.summit.ast.Node;
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTParameter extends AbstractApexNode<Node> implements CanSuppressWarnings {
+public class ASTParameter extends AbstractApexNode.Single<Node> implements CanSuppressWarnings {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPostfixExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPostfixExpression.java
@@ -8,7 +8,7 @@ import net.sourceforge.pmd.annotation.InternalApi;
 
 import com.google.summit.ast.expression.UnaryExpression;
 
-public class ASTPostfixExpression extends AbstractApexNode<UnaryExpression> {
+public class ASTPostfixExpression extends AbstractApexNode.Single<UnaryExpression> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPrefixExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPrefixExpression.java
@@ -8,7 +8,7 @@ import net.sourceforge.pmd.annotation.InternalApi;
 
 import com.google.summit.ast.expression.UnaryExpression;
 
-public class ASTPrefixExpression extends AbstractApexNode<UnaryExpression> {
+public class ASTPrefixExpression extends AbstractApexNode.Single<UnaryExpression> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTProperty.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTProperty.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTProperty extends AbstractApexNode<Node> {
+public class ASTProperty extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTReferenceExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTReferenceExpression.java
@@ -11,7 +11,7 @@ import java.util.stream.Collectors;
 
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTReferenceExpression extends AbstractApexNode<Node> {
+public class ASTReferenceExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTReturnStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTReturnStatement.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTReturnStatement extends AbstractApexNode<Node> {
+public class ASTReturnStatement extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTRunAsBlockStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTRunAsBlockStatement.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTRunAsBlockStatement extends AbstractApexNode<Node> {
+public class ASTRunAsBlockStatement extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSoqlExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSoqlExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTSoqlExpression extends AbstractApexNode<Node> {
+public class ASTSoqlExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSoslExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSoslExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTSoslExpression extends AbstractApexNode<Node> {
+public class ASTSoslExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTStandardCondition.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTStandardCondition.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTStandardCondition extends AbstractApexNode<Node> {
+public class ASTStandardCondition extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTStatement.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTStatement extends AbstractApexNode<Node> {
+public class ASTStatement extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTStatementExecuted.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTStatementExecuted.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTStatementExecuted extends AbstractApexNode<Node> {
+public class ASTStatementExecuted extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSuperMethodCallExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSuperMethodCallExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTSuperMethodCallExpression extends AbstractApexNode<Node> {
+public class ASTSuperMethodCallExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSuperVariableExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSuperVariableExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTSuperVariableExpression extends AbstractApexNode<Node> {
+public class ASTSuperVariableExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSwitchStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSwitchStatement.java
@@ -6,7 +6,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 
 import com.google.summit.ast.Node;
 
-public final class ASTSwitchStatement extends AbstractApexNode<Node> {
+public final class ASTSwitchStatement extends AbstractApexNode.Single<Node> {
 
 
     ASTSwitchStatement(Node node) {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTernaryExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTernaryExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTTernaryExpression extends AbstractApexNode<Node> {
+public class ASTTernaryExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThisMethodCallExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThisMethodCallExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTThisMethodCallExpression extends AbstractApexNode<Node> {
+public class ASTThisMethodCallExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThisVariableExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThisVariableExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTThisVariableExpression extends AbstractApexNode<Node> {
+public class ASTThisVariableExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThrowStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThrowStatement.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTThrowStatement extends AbstractApexNode<Node> {
+public class ASTThrowStatement extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTriggerVariableExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTriggerVariableExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTTriggerVariableExpression extends AbstractApexNode<Node> {
+public class ASTTriggerVariableExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTryCatchFinallyBlockStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTryCatchFinallyBlockStatement.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTTryCatchFinallyBlockStatement extends AbstractApexNode<Node> {
+public class ASTTryCatchFinallyBlockStatement extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTypeWhenBlock.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTypeWhenBlock.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import org.apache.commons.lang3.reflect.FieldUtils;
 
-public final class ASTTypeWhenBlock extends AbstractApexNode<Node> {
+public final class ASTTypeWhenBlock extends AbstractApexNode.Single<Node> {
 
 
     ASTTypeWhenBlock(Node node) {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClassMethods.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClassMethods.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTUserClassMethods extends AbstractApexNode<Node> {
+public class ASTUserClassMethods extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserExceptionMethods.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserExceptionMethods.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTUserExceptionMethods extends AbstractApexNode<Node> {
+public class ASTUserExceptionMethods extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTValueWhenBlock.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTValueWhenBlock.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 
 import com.google.summit.ast.Node;
 
-public final class ASTValueWhenBlock extends AbstractApexNode<Node> {
+public final class ASTValueWhenBlock extends AbstractApexNode.Single<Node> {
 
 
     ASTValueWhenBlock(Node node) {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableDeclaration.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableDeclaration.java
@@ -8,7 +8,7 @@ import com.google.summit.ast.Node;
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTVariableDeclaration extends AbstractApexNode<Node> implements CanSuppressWarnings {
+public class ASTVariableDeclaration extends AbstractApexNode.Single<Node> implements CanSuppressWarnings {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableDeclarationStatements.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableDeclarationStatements.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTVariableDeclarationStatements extends AbstractApexNode<Node> {
+public class ASTVariableDeclarationStatements extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableExpression.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTVariableExpression extends AbstractApexNode<Node> {
+public class ASTVariableExpression extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTWhileLoopStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTWhileLoopStatement.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTWhileLoopStatement extends AbstractApexNode<Node> {
+public class ASTWhileLoopStatement extends AbstractApexNode.Single<Node> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexCommentContainerNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexCommentContainerNode.java
@@ -11,7 +11,7 @@ import com.google.summit.ast.Node;
  *
  * @param <T> the node type
  */
-abstract class AbstractApexCommentContainerNode<T extends Node> extends AbstractApexNode<T> implements ASTCommentContainer {
+abstract class AbstractApexCommentContainerNode<T extends Node> extends AbstractApexNode.Single<T> implements ASTCommentContainer {
 
     private boolean containsComment = false;
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNode.java
@@ -13,13 +13,27 @@ import net.sourceforge.pmd.lang.ast.SourceCodePositioner;
  */
 @Deprecated
 @InternalApi
-public abstract class AbstractApexNode<T extends Node> extends AbstractApexNodeBase implements ApexNode<Void> {
+public abstract class AbstractApexNode extends AbstractApexNodeBase implements ApexNode<Void> {
 
-    protected final T node;
+    /**
+     * {@link AbstractApexNode} wrapper around a single {@link Node}.
+     *
+     * @deprecated Use {@link ApexNode}
+     */
+    @Deprecated
+    @InternalApi
+    public static abstract class Single<T extends Node> extends AbstractApexNode {
 
-    protected AbstractApexNode(T node) {
-        super(node.getClass());
-        this.node = node;
+        protected final T node;
+
+        protected Single(T node) {
+            super(node.getClass());
+            this.node = node;
+        }
+    }
+
+    protected AbstractApexNode(Class<?> klass) {
+        super(klass);
     }
 
     @Override

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexRootNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexRootNode.java
@@ -12,7 +12,7 @@ import com.google.summit.ast.CompilationUnit;
 
 @Deprecated
 @InternalApi
-public abstract class ApexRootNode<T extends CompilationUnit> extends AbstractApexNode<T> implements RootNode {
+public abstract class ApexRootNode<T extends CompilationUnit> extends AbstractApexNode.Single<T> implements RootNode {
     @Deprecated
     @InternalApi
     public ApexRootNode(T node) {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexTreeBuilder.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexTreeBuilder.java
@@ -29,7 +29,7 @@ public final class ApexTreeBuilder {
 
     private static final String DOC_COMMENT_PREFIX = "/**";
 
-    private static final Map<Class<? extends Node>, Constructor<? extends AbstractApexNode<?>>>
+    private static final Map<Class<? extends Node>, Constructor<? extends AbstractApexNode.Single<?>>>
         NODE_TYPE_TO_NODE_ADAPTER_TYPE = new HashMap<>();
 
     static {
@@ -135,7 +135,7 @@ public final class ApexTreeBuilder {
     }
 
     private static <T extends Node> void register(Class<T> nodeType,
-            Class<? extends AbstractApexNode<T>> nodeAdapterType) {
+            Class<? extends AbstractApexNode.Single<T>> nodeAdapterType) {
         try {
             NODE_TYPE_TO_NODE_ADAPTER_TYPE.put(nodeType, nodeAdapterType.getDeclaredConstructor(nodeType));
         } catch (SecurityException | NoSuchMethodException e) {
@@ -159,12 +159,12 @@ public final class ApexTreeBuilder {
         commentInfo = extractInformationFromComments(sourceCode, parserOptions.getSuppressMarker());
     }
 
-    static <T extends Node> AbstractApexNode<T> createNodeAdapter(T node) {
+    static <T extends Node> AbstractApexNode.Single<T> createNodeAdapter(T node) {
         try {
             @SuppressWarnings("unchecked")
             // the register function makes sure only ApexNode<T> can be added,
             // where T is "T extends Node".
-            Constructor<? extends AbstractApexNode<T>> constructor = (Constructor<? extends AbstractApexNode<T>>) NODE_TYPE_TO_NODE_ADAPTER_TYPE
+            Constructor<? extends AbstractApexNode.Single<T>> constructor = (Constructor<? extends AbstractApexNode.Single<T>>) NODE_TYPE_TO_NODE_ADAPTER_TYPE
                     .get(node.getClass());
             if (constructor == null) {
                 throw new IllegalArgumentException(
@@ -180,7 +180,7 @@ public final class ApexTreeBuilder {
 
     public <T extends Node> ApexNode<?> build(T astNode) {
         // Create a Node
-        AbstractApexNode<T> node = createNodeAdapter(astNode);
+        AbstractApexNode.Single<T> node = createNodeAdapter(astNode);
         node.handleSourceCode(sourceCode);
 
         // Append to parent


### PR DESCRIPTION
Remove `node` field from `AbstractApexNode` to remove restriction of wrapping a single node. Create `AbstractApexNode.Single` subclass that wraps a single node.

Other subclasses can be created as needed for common cases, or `AbstractApexNode` can be extended directly in irregular cases.